### PR TITLE
Update SpatialAction to track the target object if it moves

### DIFF
--- a/scripts/nodes/gdpai_interactable.gd
+++ b/scripts/nodes/gdpai_interactable.gd
@@ -5,6 +5,11 @@ extends GdPAIObjectData
 ## An object can specify how far away it need be.  Values <=0 disable the check.
 @export var max_interaction_distance: float = 2
 
+## The maximum distance an object can move from its planning-time position before
+## an associated spatial action is failed.
+## Values less than 0 (n<0) never trigger failure.
+@export var max_drift_from_plan: float = -1
+
 
 # Override
 func get_group_labels():
@@ -16,4 +21,5 @@ func copy_for_simulation() -> GdPAIObjectData:
 	var new_data: GdPAIInteractable = GdPAIInteractable.new()
 	assign_uid_and_entity(new_data)
 	new_data.max_interaction_distance = max_interaction_distance
+	new_data.max_drift_from_plan = max_drift_from_plan
 	return new_data

--- a/scripts/refcounteds/spatial_action.gd
+++ b/scripts/refcounteds/spatial_action.gd
@@ -135,6 +135,7 @@ func pre_perform_action(agent: GdPAIAgent) -> Action.Status:
 	agent.blackboard.set_property(uid_property("time_elapsed"), 0)
 	agent.blackboard.set_property(uid_property("target_set"), false)
 	agent.blackboard.set_property(uid_property("target_reached"), false)
+	agent.blackboard.set_property(uid_property("object_orig_position"), object_location.position)
 	agent.blackboard.set_property(uid_property("prior_positions"), [agent_location_data.position])
 
 	has_done_pre = true
@@ -146,6 +147,14 @@ func perform_action(agent: GdPAIAgent, delta: float) -> Action.Status:
 	# Failure state in the case the target has been freed.
 	if not is_instance_valid(object_location) or not is_instance_valid(interactable_attribs):
 		return Action.Status.FAILURE
+
+	# Fail if the target object has moved too far from its planning-time position.
+	var orig_position: Vector2 = agent.blackboard.get_property(uid_property("object_orig_position"))
+	var current_position: Vector2 = object_location.position
+	if interactable_attribs.max_drift_from_plan >= 0:
+		if (current_position - orig_position).length() > interactable_attribs.max_drift_from_plan:
+			return Action.Status.FAILURE
+
 
 	var nav_agent: Node = agent.blackboard.get_property(uid_property("nav_agent"))
 	var agent_location_data: GdPAILocationData = agent.blackboard.get_property(
@@ -168,6 +177,9 @@ func perform_action(agent: GdPAIAgent, delta: float) -> Action.Status:
 	if not agent.blackboard.get_property(uid_property("target_set")):
 		nav_agent.target_position = object_location.position
 		agent.blackboard.set_property(uid_property("target_set"), true)
+	# Update the nav agent target if the object has moved too far from its planning-time position.
+	elif (nav_agent.target_position - object_location.position).length() > interactable_attribs.max_interaction_distance:
+		nav_agent.target_position = object_location.position
 
 	# Terminating conditions.
 	# Either the navigation agent passes, or the agent has stopped for some other reason.
@@ -211,6 +223,7 @@ func post_perform_action(agent: GdPAIAgent) -> Action.Status:
 	agent.blackboard.erase_property(uid_property("target_reached"))
 	agent.blackboard.erase_property(uid_property("time_elapsed"))
 	agent.blackboard.erase_property(uid_property("prior_positions"))
+	agent.blackboard.erase_property(uid_property("object_orig_position"))
 
 	has_done_post = true
 	return Action.Status.SUCCESS


### PR DESCRIPTION
Adds new attribute to GdPAIInteractable to define the max distance the target is allowed to drift from it's planning-time location before the action is considered to have failed.

The `max_interaction_distance` was also used to trigger the navigation target update. This was chosen since it's the max distance an agent can interact, so theoretically, if the target moves this distance, we'll no longer be able to reach it if we were aiming for the center.