### PR TITLE
Refactor SampleAgent debug label in examples

### DIFF
--- a/examples/2D/assets/debug_label.gd
+++ b/examples/2D/assets/debug_label.gd
@@ -1,0 +1,24 @@
+extends Label
+
+## Reference to the GdPAI agent.
+@export var gdpai_agent: GdPAIAgent
+
+
+func _process(_delta: float) -> void:
+	var hunger: float = gdpai_agent.blackboard.get_property("hunger")
+	var goal_text: String
+	if gdpai_agent._current_goal != null:
+		goal_text = gdpai_agent._current_goal.get_title()
+
+	var action_text: String
+	if gdpai_agent._current_plan != null and gdpai_agent._current_plan.get_plan().size() > 0:
+		var step: int = min(
+			gdpai_agent._current_plan_step,
+			gdpai_agent._current_plan.get_plan().size() - 1,
+		)
+		var action: Action = gdpai_agent._current_plan.get_plan()[step]
+		action_text = action.get_title()
+
+	self.text = (
+		"Hunger: %.f\nGoal: %s\nCurrent Action:\n     %s" % [hunger, goal_text, action_text]
+	)

--- a/examples/2D/assets/debug_label.gd.uid
+++ b/examples/2D/assets/debug_label.gd.uid
@@ -1,0 +1,1 @@
+uid://d27ok3vvag4ck

--- a/examples/2D/assets/sample_2d_agent_animator.gd
+++ b/examples/2D/assets/sample_2d_agent_animator.gd
@@ -7,10 +7,6 @@ extends Node
 @export var animated_sprite: AnimatedSprite2D
 ## Velocity threshold for sprite animation.
 @export var idle_threshold: float = 1
-## Reference to the GdPAI agent.
-@export var gdpai_agent: GdPAIAgent
-## Reference to a textual display which shows some attributes of the agent.
-@export var display_text: Label
 
 
 func _process(_delta: float) -> void:
@@ -24,25 +20,3 @@ func _process(_delta: float) -> void:
 		animated_sprite.scale.x = -1
 	elif entity.linear_velocity.x > 0:
 		animated_sprite.scale.x = 1
-
-	# Hacky way to display the goal and action being considered at this moment.
-	var hunger: float = gdpai_agent.blackboard.get_property("hunger")
-	var goal_text: String
-	if gdpai_agent.get_current_goal() != null:
-		goal_text = gdpai_agent.get_current_goal().get_title()
-
-	var action_text: String
-	if (
-		gdpai_agent.get_current_plan() != null
-		and gdpai_agent.get_current_plan().get_plan().size() > 0
-	):
-		var step: int = min(
-			gdpai_agent.get_current_plan_step(),
-			gdpai_agent.get_current_plan().get_plan().size() - 1,
-		)
-		var action: Action = gdpai_agent.get_current_plan().get_plan()[step]
-		action_text = action.get_title()
-
-	display_text.text = (
-		"Hunger: %.f\nGoal: %s\nCurrent\nAction: %s" % [hunger, goal_text, action_text]
-	)

--- a/examples/2D/assets/sample_agent.tscn
+++ b/examples/2D/assets/sample_agent.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=23 format=3 uid="uid://b1bmo16x83s1x"]
+[gd_scene load_steps=24 format=3 uid="uid://b1bmo16x83s1x"]
 
 [ext_resource type="Texture2D" uid="uid://cqi0wac4ge1bd" path="res://examples/2D/assets/TinySwordsPack/Units/Blue Units/Monk/Idle.png" id="1_15dhw"]
 [ext_resource type="Script" uid="uid://kfoja1kvby1g" path="res://examples/2D/assets/sample_2d_nav.gd" id="2_4rrwl"]
 [ext_resource type="Texture2D" uid="uid://c2m2dh28u207a" path="res://examples/2D/assets/TinySwordsPack/Units/Blue Units/Monk/Run.png" id="2_6mdly"]
+[ext_resource type="Script" uid="uid://d27ok3vvag4ck" path="res://examples/2D/assets/debug_label.gd" id="3_3tmg3"]
 [ext_resource type="Script" uid="uid://b8t4xxrgkxf3j" path="res://examples/sample_hungry_agent.gd" id="3_qsotd"]
 [ext_resource type="Script" uid="uid://c83g2wdh6tqsp" path="res://examples/2D/assets/sample_2d_agent_animator.gd" id="4_6mdly"]
 [ext_resource type="Script" uid="uid://dadt3s5cpl0e5" path="res://addons/GdPlanningAI/scripts/nodes/gdpai_agent.gd" id="4_7hb32"]
@@ -121,7 +122,7 @@ frame_progress = 0.959604
 
 [node name="NavigationAgent2D" type="NavigationAgent2D" parent="."]
 
-[node name="Label" type="Label" parent="."]
+[node name="DebugLabel" type="Label" parent="." node_paths=PackedStringArray("gdpai_agent")]
 offset_left = -40.0
 offset_top = -157.0
 offset_right = 160.0
@@ -131,18 +132,18 @@ Goal: [Value]
 Current
 Action: [Value]"
 label_settings = SubResource("LabelSettings_6mdly")
+script = ExtResource("3_3tmg3")
+gdpai_agent = NodePath("../GdPAIAgent")
 
 [node name="SampleHungryAgent" type="Node" parent="." node_paths=PackedStringArray("gdpai_agent")]
 script = ExtResource("3_qsotd")
 gdpai_agent = NodePath("../GdPAIAgent")
 
-[node name="Sample2DAgentAnimator" type="Node" parent="." node_paths=PackedStringArray("entity", "animated_sprite", "gdpai_agent", "display_text")]
+[node name="Sample2DAgentAnimator" type="Node" parent="." node_paths=PackedStringArray("entity", "animated_sprite")]
 script = ExtResource("4_6mdly")
 entity = NodePath("..")
 animated_sprite = NodePath("../AnimatedSprite2D")
 idle_threshold = 16.0
-gdpai_agent = NodePath("../GdPAIAgent")
-display_text = NodePath("../Label")
 
 [node name="GdPAIAgent" type="Node" parent="." node_paths=PackedStringArray("entity")]
 script = ExtResource("4_7hb32")


### PR DESCRIPTION
Moves debug label code out of 2D Animator node and onto the label, to make it clearer what's part of the GdPAI setup and what's not.
Also gives a clear location of where the debug label exists if one wants to inspect it.