### PR TITLE
Refactored custom precondition creation into the _init function

### DIFF
--- a/addons/GdPlanningAI/examples/fruit_tree/sample_shake_tree_action.gd
+++ b/addons/GdPlanningAI/examples/fruit_tree/sample_shake_tree_action.gd
@@ -39,16 +39,16 @@ func get_validity_checks() -> Array[Precondition]:
 	checks.append(Precondition.agent_has_property("hunger"))
 	checks.append(Precondition.check_is_object_valid(fruit_tree))
 	checks.append(Precondition.agent_property_less_than("hunger", 100))
-
-	var on_cooldown_check: Precondition = Precondition.new()
-	on_cooldown_check.eval_func = func(
+	
+	checks.append(Precondition.new(
+		func(
 			_blackboard: GdPAIBlackboard,
 			_world_state: GdPAIBlackboard,
-	) -> bool:
+		) -> bool:
 		# Tree shouldn't have recently been shaken.
 		return not fruit_tree.is_on_cooldown
-	checks.append(on_cooldown_check)
-
+	))
+	
 	return checks
 
 

--- a/addons/GdPlanningAI/examples/wander/sample_wander_goal.gd
+++ b/addons/GdPlanningAI/examples/wander/sample_wander_goal.gd
@@ -16,19 +16,23 @@ func get_desired_state(agent: GdPAIAgent) -> Array[Precondition]:
 		"GdPAILocationData",
 	)
 	var agent_position = agent_location_data.position
-
-	var move_condition: Precondition = Precondition.new()
-	move_condition.eval_func = func(blackboard: GdPAIBlackboard, _world_state: GdPAIBlackboard):
+	
+	var move_condition: Precondition = Precondition.new(
+		func(
+			blackboard: GdPAIBlackboard,
+			_world_state: GdPAIBlackboard
+		):
 		var sim_location_data: GdPAILocationData = blackboard.get_first_object_in_group(
 			"GdPAILocationData",
 		)
 		var sim_position = sim_location_data.position
-
+		
 		# Because this example works for 2D or 3D, just specify that the moved distance should be
 		# meaningful.
 		var req_distance: float = 16 if sim_location_data.position is Vector2 else 1
 		return (sim_position - agent_position).length() > req_distance
-
+	)
+	
 	return [move_condition]
 
 

--- a/addons/GdPlanningAI/scripts/refcounteds/precondition.gd
+++ b/addons/GdPlanningAI/scripts/refcounteds/precondition.gd
@@ -52,7 +52,7 @@ func _init(_eval_func: Callable) -> void:
 	# WARNING currently can't achieve type-safety on the passed _eval_func
 	# If such a feature gets added, need to assert a signature of:
 	# func(a: GdPAIBlackboard, b: GdPAIBlackboard) -> bool
-	# See issue github.com/godotengine/godot-proposals/issues/8137
+	# See issue https://github.com/godotengine/godot-proposals/issues/10807
 	
 	eval_func = _eval_func
 

--- a/addons/GdPlanningAI/scripts/refcounteds/precondition.gd
+++ b/addons/GdPlanningAI/scripts/refcounteds/precondition.gd
@@ -44,6 +44,19 @@ var is_satisfied: bool = false
 var eval_func: Callable
 
 
+## Instanciating a Precondition with a custom check. Must match function signature:
+## [param func(blackboard: GdPAIBlackboard, world_state: GdPAIBlackboard)->bool]
+func _init(_eval_func: Callable) -> void:
+	assert(_eval_func.is_valid(), "Evaluation function is not valid")
+	
+	# WARNING currently can't achieve type-safety on the passed _eval_func
+	# If such a feature gets added, need to assert a signature of:
+	# func(a: GdPAIBlackboard, b: GdPAIBlackboard) -> bool
+	# See issue github.com/godotengine/godot-proposals/issues/8137
+	
+	eval_func = _eval_func
+
+
 ## Generic function to create property comparison preconditions, eliminating code duplication.
 static func _create_property_precondition(
 		target: Target,
@@ -51,8 +64,11 @@ static func _create_property_precondition(
 		operation: Operation,
 		value: Variant = null,
 ) -> Precondition:
-	var precondition: Precondition = Precondition.new()
-	precondition.eval_func = func(blackboard: GdPAIBlackboard, world_state: GdPAIBlackboard):
+	return Precondition.new(
+		func(
+			blackboard: GdPAIBlackboard, 
+			world_state: GdPAIBlackboard
+		):
 		var source: GdPAIBlackboard
 		match target:
 			Target.AGENT:
@@ -62,7 +78,7 @@ static func _create_property_precondition(
 			_:
 				push_error("Unknown target: %s" % target)
 				return null
-
+		
 		match operation:
 			Operation.HAS_PROPERTY:
 				return prop in source.get_dict()
@@ -81,7 +97,7 @@ static func _create_property_precondition(
 			_:
 				push_error("Unknown operation: %s" % operation)
 				return null
-	return precondition
+	)
 
 
 ## Instantiate a precondition that checks whether a property in the agent blackboard exists.
@@ -205,28 +221,37 @@ static func world_state_property_equal_to(
 
 ## Check if any of the agent's object data matches a requested group.
 static func agent_has_object_data_of_group(group: String) -> Precondition:
-	var precondition: Precondition = Precondition.new()
-	precondition.eval_func = func(blackboard: GdPAIBlackboard, _world_state: GdPAIBlackboard):
+	return Precondition.new(
+		func(
+			blackboard: GdPAIBlackboard,
+			_world_state: GdPAIBlackboard
+		):
 		var objs: Array[GdPAIObjectData] = blackboard.get_objects_in_group(group)
 		return objs.size() > 0
-	return precondition
+	)
 
 
 ## Check if any of the world state's object data matches a requested group.
 static func world_state_has_object_data_of_group(group: String) -> Precondition:
-	var precondition: Precondition = Precondition.new()
-	precondition.eval_func = func(_blackboard: GdPAIBlackboard, world_state: GdPAIBlackboard):
+	return Precondition.new(
+		func(
+			_blackboard: GdPAIBlackboard,
+			world_state: GdPAIBlackboard
+		):
 		var objs: Array[GdPAIObjectData] = world_state.get_objects_in_group(group)
 		return objs.size() > 0
-	return precondition
+	)
 
 
 ## Check if a given object is valid.
 static func check_is_object_valid(object: Variant) -> Precondition:
-	var precondition: Precondition = Precondition.new()
-	precondition.eval_func = func(_blackboard: GdPAIBlackboard, _world_state: GdPAIBlackboard):
+	return Precondition.new(
+		func(
+			_blackboard: GdPAIBlackboard,
+			_world_state: GdPAIBlackboard
+		):
 		return is_instance_valid(object)
-	return precondition
+	)
 
 
 ## Evaluates whether this precondition is satisfied by the given blackboard and world state.
@@ -242,7 +267,6 @@ func evaluate(
 
 ## Duplicate this object by creating a new instance and copying over all underlying data.
 func copy_for_simulation() -> Precondition:
-	var duplicate: Precondition = Precondition.new()
+	var duplicate: Precondition = Precondition.new(eval_func)
 	duplicate.is_satisfied = is_satisfied
-	duplicate.eval_func = eval_func
 	return duplicate

--- a/addons/GdPlanningAI/scripts/refcounteds/precondition.gd
+++ b/addons/GdPlanningAI/scripts/refcounteds/precondition.gd
@@ -47,8 +47,6 @@ var eval_func: Callable
 ## Instanciating a Precondition with a custom check. Must match function signature:
 ## [param func(blackboard: GdPAIBlackboard, world_state: GdPAIBlackboard)->bool]
 func _init(p_eval_func: Callable = Callable()) -> void:
-	if not p_eval_func.is_valid():
-		push_error("Evaluation function is not valid")
 	
 	# WARNING currently can't achieve type-safety on the passed _eval_func
 	# If such a feature gets added, need to assert a signature of:

--- a/addons/GdPlanningAI/scripts/refcounteds/precondition.gd
+++ b/addons/GdPlanningAI/scripts/refcounteds/precondition.gd
@@ -46,15 +46,16 @@ var eval_func: Callable
 
 ## Instanciating a Precondition with a custom check. Must match function signature:
 ## [param func(blackboard: GdPAIBlackboard, world_state: GdPAIBlackboard)->bool]
-func _init(_eval_func: Callable) -> void:
-	assert(_eval_func.is_valid(), "Evaluation function is not valid")
+func _init(p_eval_func: Callable = Callable()) -> void:
+	if not p_eval_func.is_valid():
+		push_error("Evaluation function is not valid")
 	
 	# WARNING currently can't achieve type-safety on the passed _eval_func
 	# If such a feature gets added, need to assert a signature of:
 	# func(a: GdPAIBlackboard, b: GdPAIBlackboard) -> bool
 	# See issue https://github.com/godotengine/godot-proposals/issues/10807
 	
-	eval_func = _eval_func
+	eval_func = p_eval_func
 
 
 ## Generic function to create property comparison preconditions, eliminating code duplication.


### PR DESCRIPTION
It was a bit annoying to have to create new Precondition objects all the time, when I only have to use them in that exact same location in the code. This is a BREAKING QoL change.

In cases where we append our preconditions into an array, this can now be inserted directly into the ``.append()`` argument, instead of having to create an object beforehand. Code like this:
```gdscript
var is_not_surrounded: Precondition = Precondition.new()

is_not_surrounded.eval_func = func(blackboard: GdPAIBlackboard, _world_state: GdPAIBlackboard):
	var agent_position: Vector2i = blackboard.get_property("entity").tilemap_position
	var available_neighbors = Globals.grid_system.get_neighbors(agent_position)
	return not available_neighbors.is_empty()

checks.append(is_not_surrounded)
```

Can now become this:
```gdscript
checks.append(Precondition.new(
	func(
		blackboard: GdPAIBlackboard, 
		_world_state: GdPAIBlackboard
	):
		var agent_position: Vector2i = blackboard.get_property("entity").tilemap_position
		var available_neighbors = Globals.grid_system.get_neighbors(agent_position)
		return not available_neighbors.is_empty()
))
```

One thing I wasn't sure about is the formatting, I formatted all ``Precondition.new()`` calls like the example above, I noticed that the existing formatting in the codebase is a bit different. Would like some feedback on that end.